### PR TITLE
fix: Ensure all titles are autoescaped in svg templates

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -16,6 +16,9 @@ from .validate import validate_color, validate_int, validate_string, validate_vi
 
 app = Flask(__name__)
 
+# enable jinja2 autoescape for all files including SVG files
+app.jinja_options["autoescape"] = lambda _: True
+
 
 @app.route("/")
 def render():


### PR DESCRIPTION
This avoids a potential XSS vulnerability, and supports certain characters such as `&` in titles which previously would cause an error.

Example with title containing ampersand:

![image](https://user-images.githubusercontent.com/20955511/193500679-99e42b63-8ba7-4a03-ad0f-53d804a2833e.png)

If this is fixed upstream (https://github.com/pallets/flask/issues/4831), this workaround won't be necessary.