### PR TITLE
fix: Temporarily use alternate default base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Check out the [Wiki](https://github.com/DenverCoder1/github-readme-youtube-cards
 | `comment_tag_name`    | The name in the comment tag for replacing content | "YOUTUBE-CARDS"                                         |
 | `youtube_api_key`     | The API key to use for features marked with 🔑    | ""                                                      |
 | `max_videos`          | The maximum number of videos to display           | 6                                                       |
-| `base_url`            | The base URL to use for the cards                 | "https://ytcards.demolab.com/"                          |
+| `base_url`            | The base URL to use for the cards                 | "https://ytcards.vercel.app/" (may change)              |
 | `card_width`          | The width of the SVG cards                        | 250                                                     |
 | `background_color`    | The background color of the SVG cards             | "#0d1117"                                               |
 | `title_color`         | The color of the title text                       | "#ffffff"                                               |

--- a/action.py
+++ b/action.py
@@ -179,7 +179,7 @@ if __name__ == "__main__":
         "--base-url",
         dest="base_url",
         help="Base URL for the readme",
-        default="https://ytcards.demolab.com/",
+        default="https://ytcards.vercel.app/",
     )
     parser.add_argument(
         "--card-width",

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
   base_url:
     description: "The base URL to use for the cards"
     required: false
-    default: "https://ytcards.demolab.com/"
+    default: "https://ytcards.vercel.app/"
   youtube_api_key:
     description: "The YouTube API key to use for additional features such a the video duration"
     required: false


### PR DESCRIPTION
The demolab CNAME records are taking a long time to propogate. In the meantime, the base url will be https://ytcards.vercel.app/ so that the cards show up.