### PR TITLE
docs(contributing): Fix action.py usage instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,10 @@ gunicorn api.index:app
 ### Running the action Python part of the workflow locally
 
 ```bash
-python action.py --channel_id=UCipSxT7a3rn81vGLw9lqRkg
+python action.py --channel=UCipSxT7a3rn81vGLw9lqRkg --comment-tag-name="EXAMPLE-YOUTUBE-CARDS"
 ```
+
+Any additional arguments can be passed to the script. Run `python action.py -h` to see the full list of arguments.
 
 ### Running tests
 


### PR DESCRIPTION
## Summary

Changed `--channel_id` to `--channel` and added the `--comment-tag-name` to avoid overriding the instructions when running locally on the repo.

Also added instructions for getting action.py help.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [x] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- If you have changed or added a feature, please describe the tests you made to verify your changes. -->

- [ ] Added or updated test cases to test new features
