### PR TITLE
refactor: Use yaml to mark languages as rtl

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -5,20 +5,21 @@ from flask import Flask, render_template, request
 from flask.wrappers import Response
 
 from .utils import (
+    data_uri_from_file,
+    data_uri_from_url,
     estimate_duration_width,
     fetch_views,
     format_relative_time,
-    data_uri_from_url,
-    data_uri_from_file,
+    is_rtl,
     seconds_to_duration,
     trim_text,
 )
 from .validate import (
     validate_color,
     validate_int,
+    validate_lang,
     validate_string,
     validate_video_id,
-    validate_lang,
 )
 
 app = Flask(__name__)
@@ -38,7 +39,6 @@ def render():
         publish_timestamp = validate_int(request, "timestamp", default=0)
         duration_seconds = validate_int(request, "duration", default=0)
         lang = validate_lang(request, "lang", default="en")
-        rtl = lang in ["ar", "he"]
         video_id = validate_video_id(request, "id")
         thumbnail = data_uri_from_url(f"https://i.ytimg.com/vi/{video_id}/mqdefault.jpg")
         views = fetch_views(video_id)
@@ -63,7 +63,7 @@ def render():
                 thumbnail=thumbnail,
                 duration=duration,
                 duration_width=duration_width,
-                rtl=rtl,
+                rtl=is_rtl(lang),
             ),
             status=200,
             mimetype="image/svg+xml",

--- a/api/locale/he.yml
+++ b/api/locale/he.yml
@@ -1,4 +1,5 @@
 he:
+  direction: rtl
   views: "%{number} צפיות"
   seconds-ago:
     one: "לפני שניה"

--- a/api/utils.py
+++ b/api/utils.py
@@ -125,3 +125,8 @@ def estimate_duration_width(duration: str) -> int:
     num_digits = len([c for c in duration if c.isdigit()])
     num_colons = len([c for c in duration if c == ":"])
     return num_digits * 7 + num_colons * 5 + 8
+
+
+def is_rtl(lang: str) -> bool:
+    """Check if language is to be displayed right-to-left"""
+    return i18n.t("direction", locale=lang, default="ltr") == "rtl"


### PR DESCRIPTION
## Summary

Instead of maintaining a list of rtl languages, it is more maintainable to add it to the configuration file for the language.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- If you have changed or added a feature, please describe the tests you made to verify your changes. -->

- [ ] Added or updated test cases to test new features
