### PR TITLE
feat: Use Babel for numbers and dates to support many locales

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -43,11 +43,7 @@ def render():
         thumbnail = data_uri_from_url(f"https://i.ytimg.com/vi/{video_id}/mqdefault.jpg")
         views = fetch_views(video_id)
         views = fetch_views(video_id, lang)
-        diff = (
-            format_relative_time(datetime.fromtimestamp(int(publish_timestamp)), lang)
-            if publish_timestamp
-            else ""
-        )
+        diff = format_relative_time(publish_timestamp, lang) if publish_timestamp else ""
         stats = f"{views} • {diff}" if views and diff else (views or diff)
         duration = seconds_to_duration(duration_seconds)
         duration_width = estimate_duration_width(duration)

--- a/api/locale/bn.yml
+++ b/api/locale/bn.yml
@@ -2,6 +2,7 @@ bn:
   views:
     one: "1 বার দেখা হয়েছে"
     many: "%{count} বার দেখা হয়েছে"
+  
   seconds-ago:
     one: "1 সেকেন্ড আগে"
     many: "%{count} সেকেন্ড আগে"

--- a/api/locale/bn.yml
+++ b/api/locale/bn.yml
@@ -1,23 +1,3 @@
 bn:
-  views:
-    one: "1 বার দেখা হয়েছে"
-    many: "%{count} বার দেখা হয়েছে"
-
-  seconds-ago:
-    one: "1 সেকেন্ড আগে"
-    many: "%{count} সেকেন্ড আগে"
-  minutes-ago:
-    one: "1 মিনিট আগে"
-    many: "%{count} মিনিট আগে"
-  hours-ago:
-    one: "1 ঘন্টা আগে"
-    many: "%{count} ঘন্টা আগে"
-  days-ago:
-    one: "1 দিন আগে"
-    many: "%{count} দিন আগে"
-  months-ago:
-    one: "1 মাস আগে"
-    many: "%{count} মাস আগে"
-  years-ago:
-    one: "1 বছর পূর্বে"
-    many: "%{count} বছর পূর্বে"
+  view: "1 বার দেখা হয়েছে"
+  views: "%{number} বার দেখা হয়েছে"

--- a/api/locale/bn.yml
+++ b/api/locale/bn.yml
@@ -1,5 +1,7 @@
 bn:
-  views: "%{number} বার দেখা হয়েছে"
+  views:
+    one: "1 বার দেখা হয়েছে"
+    many: "%{count} বার দেখা হয়েছে"
   seconds-ago:
     one: "1 সেকেন্ড আগে"
     many: "%{count} সেকেন্ড আগে"

--- a/api/locale/bn.yml
+++ b/api/locale/bn.yml
@@ -2,7 +2,7 @@ bn:
   views:
     one: "1 বার দেখা হয়েছে"
     many: "%{count} বার দেখা হয়েছে"
-  
+
   seconds-ago:
     one: "1 সেকেন্ড আগে"
     many: "%{count} সেকেন্ড আগে"

--- a/api/locale/en.yml
+++ b/api/locale/en.yml
@@ -1,5 +1,11 @@
 en:
-  views: "%{number} views"
+  # thousand, million, and billion can be left out to use the default
+  thousand: "%{count}K"
+  million: "%{count}M"
+  billion: "%{count}B"
+  views:
+    one: "1 view"
+    many: "%{count} views"
   seconds-ago:
     one: "1 second ago"
     many: "%{count} seconds ago"

--- a/api/locale/en.yml
+++ b/api/locale/en.yml
@@ -1,28 +1,3 @@
 en:
-  # leave these out to use the default
-  thousand: "%{count}K"
-  million: "%{count}M"
-  billion: "%{count}B"
-
-  views:
-    one: "1 view"
-    many: "%{count} views"
-
-  seconds-ago:
-    one: "1 second ago"
-    many: "%{count} seconds ago"
-  minutes-ago:
-    one: "1 minute ago"
-    many: "%{count} minutes ago"
-  hours-ago:
-    one: "1 hour ago"
-    many: "%{count} hours ago"
-  days-ago:
-    one: "1 day ago"
-    many: "%{count} days ago"
-  months-ago:
-    one: "1 month ago"
-    many: "%{count} months ago"
-  years-ago:
-    one: "1 year ago"
-    many: "%{count} years ago"
+  view: "1 view"
+  views: "%{number} views"

--- a/api/locale/en.yml
+++ b/api/locale/en.yml
@@ -1,11 +1,13 @@
 en:
-  # thousand, million, and billion can be left out to use the default
+  # leave these out to use the default
   thousand: "%{count}K"
   million: "%{count}M"
   billion: "%{count}B"
+
   views:
     one: "1 view"
     many: "%{count} views"
+
   seconds-ago:
     one: "1 second ago"
     many: "%{count} seconds ago"

--- a/api/locale/fa.yml
+++ b/api/locale/fa.yml
@@ -1,6 +1,8 @@
 fa:
   direction: rtl
-  views: "%{number} بازدید"
+  views:
+    one: "1 بازدید"
+    many: "%{count} بازدید"
   seconds-ago:
     one: "یک ثانیه پیش"
     many: "%{count} ثانیه پیش"

--- a/api/locale/fa.yml
+++ b/api/locale/fa.yml
@@ -1,8 +1,10 @@
 fa:
   direction: rtl
+
   views:
     one: "1 بازدید"
     many: "%{count} بازدید"
+
   seconds-ago:
     one: "یک ثانیه پیش"
     many: "%{count} ثانیه پیش"

--- a/api/locale/fa.yml
+++ b/api/locale/fa.yml
@@ -1,25 +1,4 @@
 fa:
   direction: rtl
-
-  views:
-    one: "1 بازدید"
-    many: "%{count} بازدید"
-
-  seconds-ago:
-    one: "یک ثانیه پیش"
-    many: "%{count} ثانیه پیش"
-  minutes-ago:
-    one: "یک دقیقه پیش"
-    many: "%{count} دقیقه پیش"
-  hours-ago:
-    one: "یک ساعت پیش"
-    many: "%{count} ساعت پیش"
-  days-ago:
-    one: "یک روز پیش"
-    many: "%{count} روز پیش"
-  months-ago:
-    one: "یک ماه پیش"
-    many: "%{count} ماه پیش"
-  years-ago:
-    one: "یک سال پیش"
-    many: "%{count} سال پیش"
+  view: "1 بازدید"
+  views: "%{number} بازدید"

--- a/api/locale/fr.yml
+++ b/api/locale/fr.yml
@@ -1,26 +1,3 @@
 fr:
-  thousand: "%{count} k"
-  million: "%{count} M de"
-  billion: "%{count} Md de"
-
-  views:
-    one: "1 vue"
-    many: "%{count} vues"
-  seconds-ago:
-    one: "il y a 1 seconde"
-    many: "il y a %{count} secondes"
-  minutes-ago:
-    one: "il y a 1 minute"
-    many: "il y a %{count} minutes"
-  hours-ago:
-    one: "il y a 1 heure"
-    many: "il y a %{count} heures"
-  days-ago:
-    one: "il y a 1 jour"
-    many: "il y a %{count} jours"
-  months-ago:
-    one: "il y a 1 mois"
-    many: "il y a %{count} mois"
-  years-ago:
-    one: "il y a 1 an"
-    many: "il y a %{count} ans"
+  view: "1 vue"
+  views: "%{number} vues"

--- a/api/locale/fr.yml
+++ b/api/locale/fr.yml
@@ -2,6 +2,7 @@ fr:
   thousand: "%{count} k"
   million: "%{count} M de"
   billion: "%{count} Md de"
+
   views:
     one: "1 vue"
     many: "%{count} vues"

--- a/api/locale/fr.yml
+++ b/api/locale/fr.yml
@@ -1,5 +1,10 @@
 fr:
-  views: "%{number} vues"
+  thousand: "%{count} k"
+  million: "%{count} M de"
+  billion: "%{count} Md de"
+  views:
+    one: "1 vue"
+    many: "%{count} vues"
   seconds-ago:
     one: "il y a 1 seconde"
     many: "il y a %{count} secondes"

--- a/api/locale/he.yml
+++ b/api/locale/he.yml
@@ -1,6 +1,8 @@
 he:
   direction: rtl
-  views: "%{number} צפיות"
+  views:
+    one: "1 צפייה"
+    many: "%{count} צפיות"
   seconds-ago:
     one: "לפני שניה"
     many: "לפני %{count} שניות"

--- a/api/locale/he.yml
+++ b/api/locale/he.yml
@@ -1,8 +1,10 @@
 he:
   direction: rtl
+
   views:
     one: "1 צפייה"
     many: "%{count} צפיות"
+
   seconds-ago:
     one: "לפני שניה"
     many: "לפני %{count} שניות"

--- a/api/locale/he.yml
+++ b/api/locale/he.yml
@@ -1,25 +1,4 @@
 he:
   direction: rtl
-
-  views:
-    one: "1 צפייה"
-    many: "%{count} צפיות"
-
-  seconds-ago:
-    one: "לפני שניה"
-    many: "לפני %{count} שניות"
-  minutes-ago:
-    one: "לפני דקה"
-    many: "לפני %{count} דקות"
-  hours-ago:
-    one: "לפני שעה"
-    many: "לפני %{count} שעות"
-  days-ago:
-    one: "אתמול"
-    many: "לפני %{count} ימים"
-  months-ago:
-    one: "לפני חודש"
-    many: "לפני %{count} חודשים"
-  years-ago:
-    one: "לפני שנה"
-    many: "לפני %{count} שנים"
+  view: "1 צפייה"
+  views: "%{number} צפיות"

--- a/api/locale/hi.yml
+++ b/api/locale/hi.yml
@@ -1,5 +1,7 @@
 hi:
-  views: "%{number} बार देखा गया"
+  views:
+    one: "1 बार देखा गया"
+    many: "%{count} बार देखा गया"
   seconds-ago:
     one: "1 सेकंड पहले"
     many: "%{count} सेकंड पहले"

--- a/api/locale/hi.yml
+++ b/api/locale/hi.yml
@@ -2,6 +2,7 @@ hi:
   views:
     one: "1 बार देखा गया"
     many: "%{count} बार देखा गया"
+
   seconds-ago:
     one: "1 सेकंड पहले"
     many: "%{count} सेकंड पहले"

--- a/api/locale/hi.yml
+++ b/api/locale/hi.yml
@@ -1,23 +1,3 @@
 hi:
-  views:
-    one: "1 बार देखा गया"
-    many: "%{count} बार देखा गया"
-
-  seconds-ago:
-    one: "1 सेकंड पहले"
-    many: "%{count} सेकंड पहले"
-  minutes-ago:
-    one: "1 मिनट पहले"
-    many: "%{count} मिनट पहले"
-  hours-ago:
-    one: "1 घंटे पहले"
-    many: "%{count} घंटे पहले"
-  days-ago:
-    one: "1 दिन पहले"
-    many: "%{count} दिन पहले"
-  months-ago:
-    one: "1 माह पहले"
-    many: "%{count} माह पहले"
-  years-ago:
-    one: "1 वर्ष पहले"
-    many: "%{count} वर्ष पहले"
+  view: "1 बार देखा गया"
+  views: "%{number} बार देखा गया"

--- a/api/locale/id.yml
+++ b/api/locale/id.yml
@@ -1,23 +1,3 @@
 id:
-  views:
-    one: "1 ditonton"
-    many: "%{count} ditonton"
-
-  seconds-ago:
-    one: "1 detik yang lalu"
-    many: "%{count} detik yang lalu"
-  minutes-ago:
-    one: "1 menit yang lalu"
-    many: "%{count} menit yang lalu"
-  hours-ago:
-    one: "1 jam yang lalu"
-    many: "%{count} jam yang lalu"
-  days-ago:
-    one: "1 hari yang lalu"
-    many: "%{count} hari yang lalu"
-  months-ago:
-    one: "1 bulan yang lalu"
-    many: "%{count} bulan yang lalu"
-  years-ago:
-    one: "1 tahun yang lalu"
-    many: "%{count} tahun yang lalu"
+  view: "1 ditonton"
+  views: "%{number} ditonton"

--- a/api/locale/id.yml
+++ b/api/locale/id.yml
@@ -1,5 +1,7 @@
 id:
-  views: "%{number} ditonton"
+  views:
+    one: "1 ditonton"
+    many: "%{count} ditonton"
   seconds-ago:
     one: "1 detik yang lalu"
     many: "%{count} detik yang lalu"

--- a/api/locale/id.yml
+++ b/api/locale/id.yml
@@ -2,6 +2,7 @@ id:
   views:
     one: "1 ditonton"
     many: "%{count} ditonton"
+
   seconds-ago:
     one: "1 detik yang lalu"
     many: "%{count} detik yang lalu"

--- a/api/locale/ur.yml
+++ b/api/locale/ur.yml
@@ -1,6 +1,8 @@
 ur:
   direction: rtl
-  views: "%{number} ملاحظات"
+  views:
+    one: "1 ملاحظة"
+    many: "%{count} ملاحظات"
   seconds-ago:
     one: "1 سیکنڈ پہلے"
     many: "%{count} سیکنڈ پہلے"

--- a/api/locale/ur.yml
+++ b/api/locale/ur.yml
@@ -1,25 +1,4 @@
 ur:
   direction: rtl
-
-  views:
-    one: "1 ملاحظة"
-    many: "%{count} ملاحظات"
-
-  seconds-ago:
-    one: "1 سیکنڈ پہلے"
-    many: "%{count} سیکنڈ پہلے"
-  minutes-ago:
-    one: "1 منٹ پہلے"
-    many: "%{count} منٹ پہلے"
-  hours-ago:
-    one: "1 گھنٹہ پہلے"
-    many: "%{count} گھنٹے پہلے"
-  days-ago:
-    one: "1 دن پہلے"
-    many: "%{count} دن پہلے"
-  months-ago:
-    one: "1 مہینہ پہلے"
-    many: "%{count} مہینے پہلے"
-  years-ago:
-    one: "1 سال پہلے"
-    many: "%{count} سال پہلے"
+  view: "1 ملاحظة"
+  views: "%{number} ملاحظات"

--- a/api/locale/ur.yml
+++ b/api/locale/ur.yml
@@ -1,8 +1,10 @@
 ur:
   direction: rtl
+
   views:
     one: "1 ملاحظة"
     many: "%{count} ملاحظات"
+
   seconds-ago:
     one: "1 سیکنڈ پہلے"
     many: "%{count} سیکنڈ پہلے"

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,5 +1,5 @@
 import codecs
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional
 from urllib.request import Request, urlopen
 
@@ -12,9 +12,10 @@ i18n.set("enable_memoization", True)
 i18n.load_path.append("./api/locale")
 
 
-def format_relative_time(date: datetime, lang: str = "en") -> str:
-    """Get relative time from datetime (ex. "3 hours ago")"""
-    return dates.format_timedelta(delta=date - datetime.now(), add_direction=True, locale=lang)
+def format_relative_time(timestamp: float, lang: str = "en") -> str:
+    """Get relative time from unix timestamp (ex. "3 hours ago")"""
+    delta = timedelta(seconds=timestamp - datetime.now().timestamp())
+    return dates.format_timedelta(delta=delta, add_direction=True, locale=lang)
 
 
 def data_uri_from_bytes(*, data: bytes, mime_type: str) -> str:

--- a/api/validate.py
+++ b/api/validate.py
@@ -1,4 +1,3 @@
-import os
 import re
 
 from babel import Locale, UnknownLocaleError
@@ -44,7 +43,7 @@ def validate_lang(req: Request, field: str, *, default: str = "en") -> str:
     """Validate a string with a locale lang, returns the string if the locale
     is known by Babel, otherwise the default.
     """
-    value = req.args.get(field, "")
+    value = req.args.get(field, default)
     try:
         Locale.parse(value)
     except UnknownLocaleError:

--- a/api/validate.py
+++ b/api/validate.py
@@ -1,6 +1,7 @@
 import os
 import re
 
+from babel import Locale, UnknownLocaleError
 from flask.wrappers import Request
 
 
@@ -40,12 +41,12 @@ def validate_string(req: Request, field: str, default: str = "") -> str:
 
 
 def validate_lang(req: Request, field: str, *, default: str = "en") -> str:
-    """Validate a string with a locale lang, returns the string if translations
-    are present in the locale directory, otherwise the default.
+    """Validate a string with a locale lang, returns the string if the locale
+    is known by Babel, otherwise the default.
     """
     value = req.args.get(field, "")
-    # if there is no yaml file for the language, use the default
-    if not os.path.isfile(f"./api/locale/{value}.yml"):
-        return default
-
+    try:
+        Locale.parse(value)
+    except UnknownLocaleError:
+        value = default
     return value

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==2.2.2
 gunicorn>=20.1.0
 orjson==3.8.0
 python-i18n[yaml]==0.3.9
+Babel==2.10.3

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -93,5 +93,5 @@ def test_request_right_to_left(client):
     assert 'style="direction: rtl"' in data
 
     # test views
-    views_regex = re.compile(r"\d+(?:\.\d)?[KMBT]? צפיות")
+    views_regex = re.compile(r"\d+(?:\.\d)?[KMBT]?\u200f צפיות")
     assert views_regex.search(data) is not None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,7 @@ from api.utils import (
     estimate_duration_width,
     fetch_views,
     format_relative_time,
+    format_views_value,
     seconds_to_duration,
     trim_text,
 )
@@ -17,9 +18,22 @@ def test_fetch_views():
     assert metric_regex.match(fetch_views("dQw4w9WgXcQ"))
 
 
-def test_fetch_views_i18n():
-    metric_regex = re.compile(r"^\d+(?:\.\d)?[KMBT]? vues$")
-    assert metric_regex.match(fetch_views("dQw4w9WgXcQ", "fr"))
+def test_format_views_value():
+    assert format_views_value("1") == "1 view"
+    assert format_views_value("100") == "100 views"
+    assert format_views_value("1k") == "1K views"
+    assert format_views_value("1.5k") == "1.5K views"
+    assert format_views_value("2M") == "2M views"
+    assert format_views_value("1.5G") == "1.5B views"
+
+
+def test_format_views_value_i18n():
+    assert format_views_value("1", "fr") == "1 vue"
+    assert format_views_value("100", "fr") == "100 vues"
+    assert format_views_value("1k", "fr") == "1 k vues"
+    assert format_views_value("1.5k", "fr") == "1,5 k vues"
+    assert format_views_value("2M", "fr") == "2 M de vues"
+    assert format_views_value("1.5G", "fr") == "1,5 Md de vues"
 
 
 def test_format_relative_time():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,12 +42,12 @@ def test_format_views_value_i18n():
 
 def test_format_relative_time():
     # values are handled by Babel, so we just test that the function is called successfully
-    assert format_relative_time(datetime.now() - timedelta(hours=1)) == "1 hour ago"
+    assert format_relative_time(datetime.now().timestamp() - 3600) == "1 hour ago"
 
 
 def test_format_relative_time_i18n():
     # values are handled by Babel, so we just test that the function is called successfully
-    assert format_relative_time(datetime.now() - timedelta(hours=1), "fr") == "il y a 1 heure"
+    assert format_relative_time(datetime.now().timestamp() - 3600, "fr") == "il y a 1 heure"
 
 
 def test_format_decimal_compact():


### PR DESCRIPTION
## Summary

closes #65 

* Uses Babel to translate numbers into a given locale (eg. "1.2K" => "1,2 k" in locale "fr")
* Use Babel to translate relative time differences

This formats the compact numbers in the selected locale, for example:

![image](https://user-images.githubusercontent.com/20955511/196593325-7f9f9524-6b45-4ecf-b51d-6e448191deee.png)

Locales not yet translated, can now be used for number formatting and relative time difference, but the word "views" will remain in English until translated. For example:

![image](https://user-images.githubusercontent.com/20955511/196593004-76c34fbb-6067-4def-998b-78a3020c6854.png)

> **Note**
> Compact number formats are not supported by any Babel formatters yet, but for now are implemented using the CLDR data from Babel according to the specifications at https://www.unicode.org/reports/tr35/tr35-45/tr35-numbers.html#Compact_Number_Formats.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [x] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- If you have changed or added a feature, please describe the tests you made to verify your changes. -->

- [x] Added or updated test cases to test new features
