### PR TITLE
refactor: Add status exceptions and unicode escape sequences

### DIFF
--- a/api/exceptions.py
+++ b/api/exceptions.py
@@ -1,0 +1,10 @@
+class StatusException(Exception):
+    status: int
+
+
+class ValidationError(StatusException, ValueError):
+    """Exception raised when a validation error occurs."""
+
+    def __init__(self, message, status=400):
+        super().__init__(message)
+        self.status = status

--- a/api/index.py
+++ b/api/index.py
@@ -32,7 +32,8 @@ app.jinja_options["autoescape"] = True
 def render():
     try:
         if "id" not in request.args:
-            return Response(response=render_template("index.html", now=datetime.utcnow()))
+            now = datetime.utcnow()
+            return Response(response=render_template("index.html", now=now))
         video_id = validate_video_id(request, "id")
         width = validate_int(request, "width", default=250)
         background_color = validate_color(request, "background_color", default="#0d1117")
@@ -43,10 +44,9 @@ def render():
         duration_seconds = validate_int(request, "duration", default=0)
         lang = validate_lang(request, "lang", default="en")
         thumbnail = data_uri_from_url(f"https://i.ytimg.com/vi/{video_id}/mqdefault.jpg")
-        views = fetch_views(video_id)
         views = fetch_views(video_id, lang)
         diff = format_relative_time(publish_timestamp, lang) if publish_timestamp else ""
-        stats = f"{views} • {diff}" if views and diff else (views or diff)
+        stats = f"{views}\u2002•\u2002{diff}" if views and diff else (views or diff)
         duration = seconds_to_duration(duration_seconds)
         duration_width = estimate_duration_width(duration)
         response = Response(
@@ -69,7 +69,7 @@ def render():
         response.headers["Content-Type"] = "image/svg+xml; charset=utf-8"
         return response
     except Exception as e:
-        status = getattr(e, "status", getattr(e, "code", None)) or 400
+        status = getattr(e, "status", 500)
         thumbnail = data_uri_from_file("./api/templates/resources/error.jpg")
         return Response(
             response=render_template("error.svg", message=str(e), code=status, thumbnail=thumbnail),

--- a/api/utils.py
+++ b/api/utils.py
@@ -29,6 +29,9 @@ def data_uri_from_url(url: str, *, mime_type: Optional[str] = None) -> str:
     """Return base-64 data URI for an image at a given URL.
     If not passed, the content type is determined from the response header
     if present, otherwise, jpeg is assumed.
+
+    Raises:
+        HTTPError: If the request fails
     """
     with urlopen(url) as response:
         data = response.read()

--- a/api/validate.py
+++ b/api/validate.py
@@ -3,6 +3,8 @@ import re
 from babel import Locale, UnknownLocaleError
 from flask.wrappers import Request
 
+from .exceptions import ValidationError
+
 
 def validate_int(req: Request, field: str, default: int = 0) -> int:
     """Validate an integer, returns the integer if valid, otherwise the default."""
@@ -25,12 +27,14 @@ def validate_color(req: Request, field: str, default: str = "#ffffff") -> str:
 def validate_video_id(req: Request, field: str) -> str:
     """Validate a video ID, returns the video ID if valid.
 
-    Raises ValueError if the field is not provided or fails the validation regex."""
+    Raises:
+        ValidationError: if the field is not provided or fails the validation regex.
+    """
     value = req.args.get(field, "")
     if value == "":
-        raise ValueError(f"Required parameter '{field}' is missing")
+        raise ValidationError(f"Required parameter '{field}' is missing")
     if not re.match(r"^[a-zA-Z0-9_-]+$", value):
-        raise ValueError(f"{field} expects a video ID but got '{value}'")
+        raise ValidationError(f"'{field}' expects a video ID but got '{value}'")
     return value
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -15,7 +15,7 @@ def test_request_invalid_id(client):
     data = response.data.decode("utf-8")
 
     assert response.status_code == 400
-    assert "id expects a video ID but got &#39;**********&#39;" in data
+    assert "&#39;id&#39; expects a video ID but got &#39;**********&#39;" in data
 
 
 def test_request_unknown_id(client):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,6 +1,12 @@
 import pytest
 
-from api.validate import validate_color, validate_int, validate_string, validate_video_id
+from api.validate import (
+    ValidationError,
+    validate_color,
+    validate_int,
+    validate_string,
+    validate_video_id,
+)
 
 
 def test_validate_int(req):
@@ -39,11 +45,11 @@ def test_validate_color(req):
 
 def test_validate_video_id(req):
     # missing field
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         validate_video_id(req, "id")
     # invalid field
     req.set_args(id="*********")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         validate_video_id(req, "id")
     # valid field
     req.set_args(id="abc_123-456")


### PR DESCRIPTION
## Summary

Refactored exceptions with StatusException interface and ValidationError.

Use `\uXXXX` escape codes instead of raw unicode characters for invisible spaces

Simplified exception logic, removed extra call to fetch_views, split long lines

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- If you have changed or added a feature, please describe the tests you made to verify your changes. -->

- [x] Added or updated test cases to test new features
