### PR TITLE
fix: replace use of deprecated set-output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -124,7 +124,7 @@ runs:
                 --output-only "${{ inputs.output_only }}" \
                 --output-type "${{ inputs.output_type }}" \
         ) || exit 1
-        echo "::set-output name=markdown::$(echo $UPDATE)"
+        echo "markdown=$(echo $UPDATE)" >> $GITHUB_OUTPUT
 
     - name: Commit changes
       uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
## Summary

<!-- Please include a summary of the change and which issue is fixed. -->
fixes #83 

Replaces `set-output` command with suggested alternative
```
- echo "::set-output name=markdown::$(echo $UPDATE)"
+ echo "markdown=$(echo $UPDATE)" >> $GITHUB_OUTPUT
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- If you have changed or added a feature, please describe the tests you made to verify your changes. -->

- [ ] Added or updated test cases to test new features
