### PR TITLE
feat: Support passing playlist id in GitHub action

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ Check out the [Wiki](https://github.com/DenverCoder1/github-readme-youtube-cards
 
 | Option                        | Description                                       | Default                                                 |
 | ----------------------------- | ------------------------------------------------- | ------------------------------------------------------- |
-| `channel_id`                  | The channel ID to use for the feed <sup>📺</sup>  | Required                                                |
+| `channel_id`                  | The channel ID to use for the feed <sup>📺</sup>  | "" (A channel_id or playlist_id must be provided)       |
+| `playlist_id`                 | The playlist ID to use for the feed <sup>📺</sup> | "" (A channel_id or playlist_id must be provided)       |
 | `lang`                        | The locale for views and timestamps <sup>💬</sup> | "en"                                                    |
 | `comment_tag_name`            | The text in the comment tag for replacing content | "YOUTUBE-CARDS"                                         |
 | `youtube_api_key`             | The API key to use for features marked with 🔑    | ""                                                      |
@@ -194,6 +195,31 @@ jobs:
           readme_path: README.md
           output_only: false
           output_type: markdown
+```
+
+### Example Playlist Workflow
+
+This is an example workflow for using a playlist instead of a channel.
+
+```yaml
+name: GitHub Readme YouTube Cards
+on:
+  schedule:
+    # Runs every hour, on the hour
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # Allow the job to commit to the repository
+    permissions:
+      contents: write
+    # Run the GitHub Readme YouTube Cards action
+    steps:
+      - uses: DenverCoder1/github-readme-youtube-cards@main
+        with:
+          playlist_id: PL9YUC9AZJGFHTUP3vzq4UfQ76ScBnOi-9
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ Check out the [Wiki](https://github.com/DenverCoder1/github-readme-youtube-cards
 
 | Option                        | Description                                       | Default                                                 |
 | ----------------------------- | ------------------------------------------------- | ------------------------------------------------------- |
-| `channel_id`                  | The channel ID to use for the feed <sup>📺</sup>  | "" (A channel_id or playlist_id must be provided)       |
-| `playlist_id`                 | The playlist ID to use for the feed <sup>📺</sup> | "" (A channel_id or playlist_id must be provided)       |
+| `channel_id`                  | The channel ID to use for the feed <sup>📺</sup>  | ""                                                      |
+| `playlist_id`                 | The playlist ID to use for the feed <sup>📺</sup> | ""                                                      |
 | `lang`                        | The locale for views and timestamps <sup>💬</sup> | "en"                                                    |
 | `comment_tag_name`            | The text in the comment tag for replacing content | "YOUTUBE-CARDS"                                         |
 | `youtube_api_key`             | The API key to use for features marked with 🔑    | ""                                                      |
@@ -130,7 +130,7 @@ Check out the [Wiki](https://github.com/DenverCoder1/github-readme-youtube-cards
 | `output_only`                 | Whether to skip writing to the readme file        | "false"                                                 |
 | `output_type`                 | The output syntax to use ("markdown" or "html")   | "markdown"                                              |
 
-<sup>📺</sup> A Channel ID is required. See [How to Locate Your Channel ID](https://github.com/DenverCoder1/github-readme-youtube-cards/wiki/How-to-Locate-Your-Channel-ID) in the wiki for more information.
+<sup>📺</sup> A Channel ID or Playlist ID is required. See [How to Locate Your Channel ID](https://github.com/DenverCoder1/github-readme-youtube-cards/wiki/How-to-Locate-Your-Channel-ID) in the wiki for more information. To only show Shorts, see [How to Show Only Short Videos on Your Channel](https://github.com/DenverCoder1/github-readme-youtube-cards/wiki/How-to-Show-Only-Short-Videos-on-Your-Channel).
 
 <sup>🔑</sup> Some features require a YouTube API key. See [Setting Up the Action with a YouTube API Key](https://github.com/DenverCoder1/github-readme-youtube-cards/wiki/Setting-Up-the-Action-with-a-YouTube-API-Key) in the wiki for more information.
 
@@ -219,7 +219,7 @@ jobs:
     steps:
       - uses: DenverCoder1/github-readme-youtube-cards@main
         with:
-          playlist_id: PL9YUC9AZJGFHTUP3vzq4UfQ76ScBnOi-9
+          playlist_id: PL9YUC9AZJGFFAErr_ZdK2FV7sklMm2K0J
 ```
 
 ## Contributing

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,12 @@ branding:
 inputs:
   channel_id:
     description: "The channel ID to use for the feed"
-    required: true
+    required: false
+    default: ""
+  playlist_id:
+    description: "The playlist ID to use for the feed"
+    required: false
+    default: ""
   lang:
     description: "The language you want your cards description to use"
     required: false
@@ -128,6 +133,7 @@ runs:
       run: |
         UPDATE=$(python ${{ github.action_path }}/action.py \
                 --channel "${{ inputs.channel_id }}" \
+                --playlist "${{ inputs.playlist_id }}" \
                 --lang "${{ inputs.lang }}" \
                 --comment-tag-name "${{ inputs.comment_tag_name }}" \
                 --max-videos ${{ inputs.max_videos }} \


### PR DESCRIPTION
## Summary

Fixes #174 

Resolves #92  - Note: For shorts only, use channel id as the playlist id but replace "UC" with "UUSH". For long-form only replace "UC" with "UULF". (https://stackoverflow.com/a/76602819/11608064 - thanks @airscholar)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [x] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- If you have changed or added a feature, please describe the tests you made to verify your changes. -->

- [x] Added or updated test cases to test new features
