### PR TITLE
💬 Adds Hungarian Translation

### DIFF
--- a/api/locale/hu.yml
+++ b/api/locale/hu.yml
@@ -1,0 +1,3 @@
+hu:
+  view: "1 megtekintés"
+  views: "%{number} megtekintés"


### PR DESCRIPTION
## Summary

Adds Hungarian translation

Although Hungarian has both singular and plural forms of "view" (megtekintés and megtekintések), using the plural in this context—like 100 megtekintések—feels unnatural. That’s why we use the singular form for both cases. YouTube does the same: regardless of whether there’s 1 or 1,000 views, it always displays megtekintés.

It’s the same for likes and subscriptions too—YouTube consistently uses the singular form by default.

I’ve included a screenshot showing YouTube’s default usage as well.

![image](https://github.com/user-attachments/assets/d8e67783-2632-478d-8ecb-c1ade11eed4c)


## Type of change

- [ x ] Bug fix (added a non-breaking change which fixes an issue)

